### PR TITLE
Custom JSON logging formatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-python-json-logger~=0.1.0

--- a/useful/logs/_context.py
+++ b/useful/logs/_context.py
@@ -1,5 +1,6 @@
 import threading
 
+
 class _Context(threading.local):
     """
     threading.local with additional methods for saving and restoring state.
@@ -27,7 +28,7 @@ class _Context(threading.local):
         """
         Remove all data stored in _Context.
         """
-        for key in self.__dict__.keys():
+        for key in list(self.__dict__.keys()):
             delattr(self, key)
 
 

--- a/useful/logs/_json_logging.py
+++ b/useful/logs/_json_logging.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from useful.logs._context import context
+
 # a set of standard LogRecord attributes to be used when building JSON logs
 LOG_RECORD_ATTRIBUTES = {
     'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
@@ -86,5 +88,8 @@ class JSONFormatter(logging.Formatter):
                 continue
 
             data[field] = value
+
+        # add the data from useful.logs.context
+        data = {**data, **context.__dict__}
 
         return json.dumps(data)

--- a/useful/logs/_json_logging.py
+++ b/useful/logs/_json_logging.py
@@ -1,0 +1,90 @@
+import json
+import logging
+
+# a set of standard LogRecord attributes to be used when building JSON logs
+LOG_RECORD_ATTRIBUTES = {
+    'args', 'asctime', 'created', 'exc_info', 'exc_text', 'filename',
+    'funcName', 'levelname', 'levelno', 'lineno', 'module', 'msecs', 'message',
+    'msg', 'name', 'pathname', 'process', 'processName', 'relativeCreated',
+    'stack_info', 'thread', 'threadName'}
+
+
+class JSONFormatter(logging.Formatter):
+    """
+    Simple logging formatter using JSON serialization.
+    """
+    def __init__(self, fields=None, always_extra=None, datefmt=None):
+        """
+        Args:
+            fields (dict, optional): A dictionary of fields to use in the log.
+                The keys in the dictionary are keys that will be used in the
+                final log form, and its values are the names of the attributes
+                from the log record to use as final log values. Defaults to
+                None, which is interpreted as an empty dict.
+            always_extra (dict, optional): A dictionary of additional static
+                values written to the final log. Defaults to None, which is
+                interpreted as an empty dict.
+            datefmt (str, optional): strftime date format. For more details
+                check logging.Formatter documentation. Defaults to None.
+        """
+        super().__init__(fmt=None, datefmt=datefmt, style='%')
+        self.fields = fields or {}
+        self.always_extra = always_extra or {}
+
+    def usesTime(self):
+        """
+        Check if the format uses the creation time of the record.
+        """
+        return "asctime" in self.fields
+
+    def format(self, record):
+        """
+        Build a JSON serializable dict starting from `self.always_extra`,
+        adding the data from the LogRecord specified in `self.fields`, and
+        finally adding the record specific extra data.
+
+        Args:
+            record (logging.LogRecord): log record to be converted to string
+
+        Returns:
+            string: JSON serialized log record
+        """
+        # start with always_extra data to prevent overriding log record data
+        data = self.always_extra.copy()
+
+        # format non-serializable record values. For more details see method
+        # logging.Formatter.format()
+        record.message = record.getMessage()
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        record.stack_info = self.formatStack(record.stack_info)
+
+        # extract wanted fields from log record
+        for key, field in self.fields.items():
+            value = record.__dict__.get(field, None)
+
+            # use cached exception traceback
+            if field == "exc_info":
+                value = record.exc_text
+
+            # skip record fields without data
+            if value:
+                data[key] = value
+
+        # copy only LogRecord extra
+        for field, value in record.__dict__.items():
+            # skip all standard fields
+            if field in LOG_RECORD_ATTRIBUTES:
+                continue
+            # skip all internal variables and names
+            if field.startswith("_"):
+                continue
+
+            data[field] = value
+
+        return json.dumps(data)

--- a/useful/logs/_json_logging.py
+++ b/useful/logs/_json_logging.py
@@ -31,13 +31,15 @@ class JSONFormatter(logging.Formatter):
         """
         super().__init__(fmt=None, datefmt=datefmt, style='%')
         self.fields = fields or {}
+        self._uses_time = "asctime" in self.fields.values()
         self.always_extra = always_extra or {}
 
     def usesTime(self):
         """
-        Check if the format uses the creation time of the record.
+        Check if the format uses the creation time of the record. For more
+        information about the method see logging.Formatter.
         """
-        return "asctime" in self.fields
+        return self._uses_time
 
     def format(self, record):
         """

--- a/useful/logs/_setup.py
+++ b/useful/logs/_setup.py
@@ -17,7 +17,8 @@ JSON_FIELDS = {
     "process_name": "processName",
     "thread": "thread",
     "thread_name": "threadName",
-    "traceback": "exc_text"
+    "traceback": "exc_text",
+    "__htime": "asctime"
 }
 
 
@@ -59,7 +60,8 @@ def setup(logger=None, path=None, log_level=logging.INFO, json_logging=True,
 
     if json_logging:
         formatter = JSONFormatter(fields=json_fields,
-                                  always_extra={"source": "python"})
+                                  always_extra={"source": "python"},
+                                  datefmt="%Y-%m-%dT%H:%M:%SZ")
     else:
         formatter = logging.Formatter(
             "%(asctime)s [%(levelname)s] %(pathname)s:%(lineno)d "

--- a/useful/logs/_setup.py
+++ b/useful/logs/_setup.py
@@ -2,103 +2,28 @@ import logging
 import platform
 import sys
 
-from pythonjsonlogger import jsonlogger
+from useful.logs._json_logging import JSONFormatter
 
-from useful.logs._context import context
-
-# Default json logging values. Everything except message is set automatically
-SUPPORTED_KEYS = [
-    'asctime',
-    'created',
-    'filename',
-    'funcName',
-    'levelname',
-    'levelno',
-    'lineno',
-    'module',
-    'msecs',
-    'message',
-    'name',
-    'pathname',
-    'process',
-    'processName',
-    'relativeCreated',
-    'thread',
-    'threadName'
-]
-
-
-def _log_format(x):
-    """
-    Take an iterable of strings and convert them into a logging formatter
-    compatible format: %(variable_name)
-
-    Args:
-        x ([str]): An iterable of strings to format
-
-    Returns:
-        [str]: A list of formatted strings
-    """
-    return ['%({})'.format(i) for i in x]
-
-
-class ContextualJsonFormatter(jsonlogger.JsonFormatter):
-    """
-    A custom JsonFormatter implementation that adds {"src": "python"} to
-    JSON log.
-    """
-    def add_fields(self, log_record, record, message_dict):
-        super().add_fields(log_record, record, message_dict)
-        # add {"src": "python"} to log record
-        log_record["src"] = "python"
-        # add log values from the useful.logs.context
-        for key, value in context.__dict__.items():
-            log_record[key] = value
+# default JSONFormatter fields
+JSON_FIELDS = {
+    "message": "message",
+    "time": "created",
+    "log_level": "levelname",
+    "process": "process",
+    "process_name": "processName",
+    "thread": "thread",
+    "thread_name": "threadName",
+    "traceback": "exc_text"
+}
 
 
 def setup(logger=None, path=None, log_level=logging.INFO, json_logging=True,
-          supported_keys=None):
+          json_fields=None):
     """
     Setup logging.Logger handlers and formatters. If `json_logging` is set to
-    `True`, use json formatting per single message, otherwise use regular
-    formatting.
-
-    If `json_logging=True`, when running `logger.info(msg, extra={...})`, `msg`
-    is parsed as key `"message"`, and everything in dict provided as `extra` is
-    added to the final log. This provides a simple way to add custom metrics to
-    logs.
-
-    Note:
-        The important thing to notice is that every key from supported_keys
-        (or SUPPORTED_KEYS as default) except `"message"` is filled
-        automatically, and these keys **must** not be overriden in `extra`.
-        When calling
-
-            `logger.info("testing", extra={"app": "AppName", "metric": 1.2})`
-
-        we get a json in form of:
-
-                    {
-                        "asctime": "2019-08-22 11:09:33,805",
-                        "created": 1566464973.8052688,
-                        "filename": "main.py",
-                        "funcName": "<module>",
-                        "levelname": "INFO",
-                        "levelno": 20,
-                        "lineno": 8,
-                        "module": "main",
-                        "msecs": 805.2687644958496,
-                        "message": "testing",
-                        "name": "root",
-                        "pathname": "/path/to/main.py",
-                        "process": 32621,
-                        "processName": "MainProcess",
-                        "relativeCreated": 35.19701957702637,
-                        "thread": 139825143863104,
-                        "threadName": "MainThread",
-                        "app": "AppName",
-                        "metric": 1.2
-                    }
+    `True`, use custom JSONFormatter, otherwise use regular formatting.
+    JSONFormatter supports provides a simple way to write log message, standard
+    LogRecord values along with extra keys provided when writing logs.
 
     Args:
         logger (logging.Logger): A Logger instance to setup. Defaults to None.
@@ -108,13 +33,14 @@ def setup(logger=None, path=None, log_level=logging.INFO, json_logging=True,
         log_level (int, optional): Set logging level. Defaults to logging.INFO.
         json_logging (boolean, optional): JSON logging format usage indicator.
             Defaults to True.
-        supported_keys (list, optional): set json logging supported keys.
-            Defaults to None, which uses SUPPORTED_KEYS.
+        json_fields (dict, optional): A dictionary specifying JSONFormatter
+            log form. For more details check the documentation of the
+            formatter. Defaults to None, which is interpreted as JSON_FIELDS
 
     Returns:
         logging.Logger: The first argument (logger) after setup.
     """
-    supported_keys = supported_keys or SUPPORTED_KEYS
+    json_fields = json_fields or JSON_FIELDS
     if logger is None:
         logger = logging.getLogger()
 
@@ -128,8 +54,8 @@ def setup(logger=None, path=None, log_level=logging.INFO, json_logging=True,
         handler = logging.FileHandler(path)
 
     if json_logging:
-        custom_format = ' '.join(_log_format(supported_keys))
-        formatter = ContextualJsonFormatter(custom_format)
+        formatter = JSONFormatter(fields=json_fields,
+                                  always_extra={"source": "python"})
     else:
         formatter = logging.Formatter(
             "%(asctime)s [%(levelname)s] %(pathname)s:%(lineno)d "
@@ -137,4 +63,5 @@ def setup(logger=None, path=None, log_level=logging.INFO, json_logging=True,
 
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
     return logger

--- a/useful/logs/exception_hooks.py
+++ b/useful/logs/exception_hooks.py
@@ -1,0 +1,54 @@
+import logging
+
+
+def except_logging(exc_type, exc_value, exc_traceback):
+    """
+    Log uncaught exceptions using the root logger. This is a function meant to
+    be set as `sys.excepthook` to provide unified logging for regular logs and
+    uncaught exceptions.
+
+    Args:
+        exc_type (type): Exception type
+        exc_value (Exception) : Exception value
+        exc_traceback (traceback): Exception traceback
+    """
+    logging.exception("Uncaught exception", exc_info=exc_value)
+
+
+def threading_except_logging(exc_type, exc_value=None, exc_traceback=None,
+                             thread=None):
+    """
+    Log uncaught exceptions from different threads using the root logger. This
+    is a function meant to be set as `threading.excepthook` to provide unified
+    logging for regular logs and uncaught exceptions from different threads.
+
+    Note: Only supported since Python version 3.8
+
+    Args:
+        exc_type (type): Exception type
+        exc_value (Exception): Exception value, can be None. Defaults to None
+        exc_traceback (traceback): Exception traceback, can be None. Defaults
+            to None
+        thread (threading.Thread): Thread which raised the exception, can be
+            None. Defaults to None
+    """
+    logging.exception("Uncaught threading exception", exc_info=exc_value)
+
+
+def unraisable_logging(exc_type, exc_value=None, exc_traceback=None,
+                       err_msg=None, object=None):
+    """
+    Log unraisable exceptions using the root logger. This is a function meant
+    to be set as `sys.unraisablehook` to provide unified logging for regular
+    logs and unraisable exceptions.
+
+    Args:
+        exc_type (type): Exception type
+        exc_value (Exception): Exception value, can be None. Defaults to None
+        exc_traceback (traceback): Exception traceback, can be None. Defaults
+            to None
+        err_msg (str): Error message, can be None. Defaults to None
+        object (object): Object causing the exception, can be None. Defaults to
+            None
+    """
+    logging.exception("Unraisable exception", exc_info=exc_value)


### PR DESCRIPTION
* replace the JSON formatter implementation from `python-json-logging` with a simpler, custom version
* add exception hooks for logging uncaught and unraisable exceptions using the root logger. The main purpose is to use JSON format for all errors to avoid multiline parsing
* fix `useful.log._Context` dictionary modification bug